### PR TITLE
fix: add missing link and update existing link reference

### DIFF
--- a/docs/guides/github/github-profile.md
+++ b/docs/guides/github/github-profile.md
@@ -4,9 +4,9 @@ title: Github Profile
 sidebar_position: 1
 ---
 
-GitHub provides users with the ability to customize their profile pages by creating a profile readme file. You can learn more about managing your GitHub readme here.
+GitHub provides users with the ability to customize their profile pages by creating a profile readme file. You can learn more about managing your GitHub readme [here](https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-github-profile/customizing-your-profile/managing-your-profile-readme).
 
-In short, the readme file is a simple markdown file that can be used to describe yourself. GitHub has a wide range of support for markdown features and if you are new to markdown, you can find an introduction from GitHub [here](https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-github-profile/customizing-your-profile/managing-your-profile-readme).
+In short, the readme file is a simple markdown file that can be used to describe yourself. GitHub has a wide range of support for markdown features and if you are new to markdown, you can find an introduction from GitHub [here](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax).
 
 We have taken advantage of this awesome Github feature by leveraging the basic HTML support provided to embed our Developer Cards.
 


### PR DESCRIPTION
# Description

Added missing link to github profile to reference the Github profile readmes.  
Updating existing duplicate link to reference relevant Github docs for markdown syntax.