### PR TITLE
Fixed the TQLA hyperlink to the correct one

### DIFF
--- a/docs/introduction/example_repository.md
+++ b/docs/introduction/example_repository.md
@@ -7,7 +7,7 @@ sidebar_position: 3
 
 ## Achievement Configuration in Example and TQLA Repositories
 
-At Vaunt, we've set up achievements in the [Example](https://github.com/VauntDev/example?tab=readme-ov-file#available-awards) and [TQLA](https://github.com/VauntDev/example) repositories to showcase how Vaunt facilates open-source community building and engagment. 
+At Vaunt, we've set up achievements in the [Example](https://github.com/VauntDev/example?tab=readme-ov-file#available-awards) and [TQLA](https://github.com/VauntDev/tqla/tree/main) repositories to showcase how Vaunt facilates open-source community building and engagment. 
 
 The Example repo provides a basic set of free achievements, ideal for initial testing, or projects that are just getting started. Also, we have a quick onboarding guildline in the repo. On the other hand, the TQLA repo have more advanced achievements to drive and foster community engagement. Learn how to set up achievements [here](https://github.com/VauntDev/docs/blob/simon-docs/docs/organizations/achievements.md).
 


### PR DESCRIPTION
In the example repo page, the TQLA Hyperlink was wrong. So, I changed it to the correct hyperlink