### PR TITLE
docs: making the Creating a PAT tutorial concise and clear.

### DIFF
--- a/docs/organizations/private_repository/creating-a-pat.md
+++ b/docs/organizations/private_repository/creating-a-pat.md
@@ -4,32 +4,24 @@ title: Creating a PAT
 sidebar_position: 1
 ---
 
-A few of the Vaunt API routes require the user to provide authorization with a provider such as Github. We refer to this authorization as attestation as we are
-using Github to validate that you are who you say you are. Once attestation is performed with a valid Github personal access token you can generate a Vaunt JWT that can
-be used for future API calls.
+Some Vaunt API routes require Github authorization to verify your identity. After validating with a Github personal access token, you can generate a Vaunt JWT for future API calls.
+This can be done on Github by creating and using a fine-grained Personal Access Token. See **[Creating a fine-grained personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token)** for more information.
 
-This can be done on Github by creating and using a fine-grained Personal Access Token. See **[Creating a fine-grained personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token)** on Github for instructions on creating a token.
+For user attestation, the token does not require any additional permissions or repository access. Vaunt only uses it to verify your Github user ID matches the entity.
 
-For the purposes of attestation a token for your own user does not need to have any additional permissions selected. It is only used to verify that you are
-the entity that you are requesting data for. You additionally do not need to select any repositories for access with this token. The only thing Vaunt will do is verify
-that your user id in Github matches the entity.
+![User PAT permissions](../assets/user_pat.png)
 
-See an example of the permissions for a user token below.
+To create a token for validating your organization admin status and retrieving data, generate an organization token with Read-only access to Members under the organization permissions. This access level allows Vaunt to verify your admin status through Github.
 
-<p>
-    <img src={require('../assets/user_pat.png').default} width="500" />
-</p>
+![Organization PAT permissions](../assets/organization_permissions.png)
 
-If you want to create a token that can be used to validate you are an Admin of an organization to retrieve data for then you should create a token for that organization and give the token Read-only access to the Members under the organization permissions. Read access to members is used to confirm with Github that you are an Admin of the organization. Currently, an admin of the organization must be the one to create the token for attestation.
+:::note
+ only organization administrators can create tokens for organization attestation.
 
-See an example of the permissions for an organization token below.
+After generating a token you can use the token value with the `Authorization` header in requests to the Vaunt API.
 
-<p>
-    <img src={require('../assets/organization_permissions.png').default} width="500" />
-</p>
+Here's an example of a request to the Vaunt API using a Github PAT:
 
-After generating a token you can use the token value with the `Authorization` header in requests to the Vaunt API, for Example:
-
-```Bash
+```bash
 curl -v -H "content-type: application/json" -H "Authorization: Bearer <GITHUB_PAT>" http://api.vaunt.dev/v1/github/entities/<entity>/token
 ```

--- a/docs/organizations/private_repository/creating-a-pat.md
+++ b/docs/organizations/private_repository/creating-a-pat.md
@@ -16,7 +16,8 @@ To create a token for validating your organization admin status and retrieving d
 ![Organization PAT permissions](../assets/organization_permissions.png)
 
 :::note
- only organization administrators can create tokens for organization attestation.
+ Only organization administrators can create tokens for organization attestation.
+:::
 
 After generating a token you can use the token value with the `Authorization` header in requests to the Vaunt API.
 


### PR DESCRIPTION
## Description
This PR improves the [Creating a PAT](https://docs.vaunt.dev/organizations/private_repository/creating-a-pat) page. 

### Issues
Fixes #50 

### Proposed Changes

- Making the images adhere more to Markdown format
- Made the paragraphs shorter 
- Improved the code snippets
- Revise grammar and mechanic errors 

#### Screenshots

**Before**

![current version of tutorial](https://github.com/user-attachments/assets/762af8c4-4850-4d1f-8409-c482ca6c8c33)


**After**

![improved tutorial page](https://github.com/user-attachments/assets/23bf9de2-1c0e-4782-a447-10421a246e4e)


